### PR TITLE
feat: add offense class

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ require 'tainted'
 file = "#{__dir__}/../fixtures/simple.rb"
 lint = Tainted::Lint.new(file, %i[tainted], %i[unsafe])
 lint.analyze
-# Method `unsafe()` consuming tainted variable `d`
-# Method `unsafe()` consuming tainted variable `c`
+=>
+[#<Tainted::Offense:0x0000000107caf690
+  @message="Method `unsafe()` consuming tainted variable `d`",
+  @node=(call nil nil (ident "unsafe") (arg_paren (args ((var_ref (ident "d"))))))>,
+ #<Tainted::Offense:0x0000000107caf5f0
+  @message="Method `unsafe()` consuming tainted variable `c`",
+  @node=(call nil nil (ident "unsafe") (arg_paren (args ((var_ref (ident "c"))))))>]
 ```
 
 ## Development

--- a/lib/tainted.rb
+++ b/lib/tainted.rb
@@ -6,6 +6,7 @@ require_relative "tainted/state"
 require_relative "tainted/static"
 require_relative "tainted/lint"
 require_relative "tainted/dataflow"
+require_relative "tainted/offense"
 require_relative "tainted/version"
 
 module Tainted

--- a/lib/tainted/lint.rb
+++ b/lib/tainted/lint.rb
@@ -15,7 +15,7 @@ module Tainted
 
     def analyze
       @visitor.visit(SyntaxTree.parse_file(@filepath))
-      @visitor.result
+      @visitor.offenses
     end
   end
 end

--- a/lib/tainted/offense.rb
+++ b/lib/tainted/offense.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Tainted
+  class Offense
+    attr_reader :node, :message
+
+    def initialize(node, message)
+      @node = node
+      @message = message
+    end
+  end
+end

--- a/lib/tainted/static.rb
+++ b/lib/tainted/static.rb
@@ -2,14 +2,14 @@
 
 module Tainted
   class Static < SyntaxTree::Visitor
-    attr_reader :result
+    attr_reader :offenses
 
     def initialize(sources, sinks)
       super()
 
       @sources = sources
       @sinks = sinks
-      @result = []
+      @offenses = []
     end
 
     def visit(node)
@@ -58,7 +58,7 @@ module Tainted
       taint_statuses.each do |status|
         next unless status[1]
 
-        @result << "Method `#{method_name}()` consuming tainted variable `#{status[0].value.value}`"
+        @offenses << Offense.new(node, "Method `#{method_name}()` consuming tainted variable `#{status[0].value.value}`")
       end
     end
 

--- a/lib/tainted/version.rb
+++ b/lib/tainted/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tainted
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/lib/tainted/lint_spec.rb
+++ b/spec/lib/tainted/lint_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Tainted::Lint do
     it "returns a result listing the taint errors" do
       file = File.expand_path "#{__dir__}/../../fixtures/simple.rb"
       lint = Tainted::Lint.new(file, %i[tainted], %i[unsafe])
-      result = lint.analyze
+      result = lint.analyze.map { |offense| offense.message }
 
       expect(result).to eq(
         [
@@ -18,7 +18,7 @@ RSpec.describe Tainted::Lint do
     it "returns issue for sql query from unsanitized param" do
       file = File.expand_path "#{__dir__}/../../fixtures/params.rb"
       lint = Tainted::Lint.new(file, %i[params], %i[execute])
-      result = lint.analyze
+      result = lint.analyze.map { |offense| offense.message }
 
       expect(result).to eq(
         [


### PR DESCRIPTION
## Description

Add a rubocop-like `Offense` class that contains the `node` and `message` children.